### PR TITLE
Add "hotkey enables" option to default excavate / hold to disable

### DIFF
--- a/src/main/java/net/kyrptonaught/diggusmaximus/config/ConfigOptions.java
+++ b/src/main/java/net/kyrptonaught/diggusmaximus/config/ConfigOptions.java
@@ -9,6 +9,9 @@ public class ConfigOptions implements AbstractConfigFile {
     @Comment("Mod enabled or disabled")
     public boolean enabled = true;
 
+    @Comment("Hold keybind to excavate (false: hold to disable excavate)")
+    public boolean hotkeyEnables = true;
+
     @Comment("Activation key")
     public String keybinding = "key.keyboard.grave.accent";
 

--- a/src/main/java/net/kyrptonaught/diggusmaximus/config/modmenu/ModMenuIntegration.java
+++ b/src/main/java/net/kyrptonaught/diggusmaximus/config/modmenu/ModMenuIntegration.java
@@ -44,6 +44,7 @@ public class ModMenuIntegration implements ModMenuApi {
             ConfigCategory category = builder.getOrCreateCategory(new TranslatableText("key.diggusmaximus.config.category"));
             category.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("key.diggusmaximus.config.enabled"), options.enabled).setSaveConsumer(val -> options.enabled = val).setDefaultValue(true).build());
 
+            category.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("key.diggusmaximus.config.hotkeyenables"), options.hotkeyEnables).setSaveConsumer(val -> options.hotkeyEnables = val).setDefaultValue(true).build());
             category.addEntry(entryBuilder.startKeyCodeField(new TranslatableText("key.diggusmaximus.config.hotkey"), InputUtil.fromTranslationKey(options.keybinding)).setSaveConsumer(key -> options.keybinding = key.getTranslationKey()).build());
             category.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("key.diggusmaximus.config.minediag"), options.mineDiag).setSaveConsumer(val -> options.mineDiag = val).setDefaultValue(true).build());
             category.addEntry(entryBuilder.startIntField(new TranslatableText("key.diggusmaximus.config.maxmine"), options.maxMinedBlocks).setSaveConsumer(val -> options.maxMinedBlocks = val).setDefaultValue(40).setMin(1).setMax(2048).build());

--- a/src/main/java/net/kyrptonaught/diggusmaximus/mixin/MixinClientPlayerInteractionManager.java
+++ b/src/main/java/net/kyrptonaught/diggusmaximus/mixin/MixinClientPlayerInteractionManager.java
@@ -29,7 +29,7 @@ public abstract class MixinClientPlayerInteractionManager {
 
     @Inject(method = "sendPlayerAction", at = @At(value = "HEAD"), cancellable = true)
     private void DIGGUS$BLOCKBREAK(PlayerActionC2SPacket.Action action, BlockPos blockPos, Direction direction, CallbackInfo ci) {
-        if (DiggusMaximusMod.getOptions().enabled && DiggusMaximusMod.isKeybindPressed()) {
+        if (DiggusMaximusMod.getOptions().enabled && (DiggusMaximusMod.getOptions().hotkeyEnables == DiggusMaximusMod.isKeybindPressed())) {
             PlayerActionC2SPacket.Action requiredAction = this.gameMode == GameMode.CREATIVE ? PlayerActionC2SPacket.Action.START_DESTROY_BLOCK : PlayerActionC2SPacket.Action.STOP_DESTROY_BLOCK;
             if (action.equals(requiredAction) || this.client.world.getBlockState(blockPos).calcBlockBreakingDelta(this.client.player, this.client.player.world, blockPos) >= 1.0f) {
                 StartExcavatePacket.sendExcavatePacket(blockPos);

--- a/src/main/resources/assets/diggusmaximus/lang/en_us.json
+++ b/src/main/resources/assets/diggusmaximus/lang/en_us.json
@@ -3,6 +3,7 @@
   "key.diggusmaximus.excavate": "Excavate",
   "key.diggusmaximus.config.category": "Options",
   "key.diggusmaximus.config.enabled": "Enabled",
+  "key.diggusmaximus.config.hotkeyenables": "Hold keybind to excavate (false: hold to disable excavate)",
   "key.diggusmaximus.config.hotkey": "Keybind",
   "key.diggusmaximus.config.minediag": "Mine blocks diagonally",
   "key.diggusmaximus.config.maxmine": "Max mined blocks",


### PR DESCRIPTION
Allows for "always on" mode like the original veinminer when used with a whitelist of ores.