### PR TITLE
Add default tag groupings

### DIFF
--- a/src/main/java/net/kyrptonaught/diggusmaximus/ExcavateHelper.java
+++ b/src/main/java/net/kyrptonaught/diggusmaximus/ExcavateHelper.java
@@ -45,7 +45,7 @@ public class ExcavateHelper {
                 newID = startID;
 
         } */
-        if (DiggusMaximusMod.getGrouping().customGrouping) {
+        if (DiggusMaximusMod.getGrouping().defaultTagGrouping || DiggusMaximusMod.getGrouping().customGrouping) {
             newID = DiggusMaximusMod.getIDFromConfigLookup(newID);
             startID = DiggusMaximusMod.getIDFromConfigLookup(startID);
         }

--- a/src/main/java/net/kyrptonaught/diggusmaximus/config/BlockCategory.java
+++ b/src/main/java/net/kyrptonaught/diggusmaximus/config/BlockCategory.java
@@ -6,12 +6,23 @@ import net.kyrptonaught.kyrptconfig.config.AbstractConfigFile;
 import net.minecraft.util.Identifier;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Stream;
 
 public class BlockCategory implements AbstractConfigFile {
+
+    @Comment("Enable default block groupings for certain tags (e.g. Stone & Deepslate Ores)")
+    public boolean defaultTagGrouping = true;
+
+    private final List<String> defaultTagGroups = Arrays.asList(
+            "#coal_ores", "#iron_ores", "#lapis_ores", "#redstone_ores",
+            "#copper_ores", "#gold_ores", "#emerald_ores", "#diamond_ores");
+
     @Comment("Enable block custom grouping")
     public boolean customGrouping = false;
+
     @Comment("BlockID to be considered the same block when excavating (IDs separated by commas)")
     public List<String> groups = new ArrayList<>();
 
@@ -19,6 +30,16 @@ public class BlockCategory implements AbstractConfigFile {
 
     public void generateLookup() {
         lookup.clear();
+        if (defaultTagGrouping) {
+            appendGroupsToLookup(defaultTagGroups);
+        }
+
+        if (customGrouping) {
+            appendGroupsToLookup(groups);
+        }
+    }
+
+    private void appendGroupsToLookup(List<String> groups) {
         groups.forEach(group -> {
             List<Identifier> expanded = new ArrayList<>();
             for (String item : group.split(",")) {

--- a/src/main/java/net/kyrptonaught/diggusmaximus/config/modmenu/ModMenuIntegration.java
+++ b/src/main/java/net/kyrptonaught/diggusmaximus/config/modmenu/ModMenuIntegration.java
@@ -72,7 +72,7 @@ public class ModMenuIntegration implements ModMenuApi {
 
             BlockCategory grouping = DiggusMaximusMod.getGrouping();
             ConfigSection groupSection = new ConfigSection(configScreen, Text.translatable("key.diggusmaximus.config.groupcat"));
-            groupSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.defaulttaggroups"), grouping.defaultTagGroupings, true).setSaveConsumer(val -> grouping.defaultTagGroupings = val));
+            groupSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.defaulttaggroups"), grouping.defaultTagGrouping, true).setSaveConsumer(val -> grouping.defaultTagGrouping = val));
             groupSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.customgrouping"), grouping.customGrouping, false).setSaveConsumer(val -> grouping.customGrouping = val));
             groupSection.addConfigItem(new GroupingList(Text.translatable("key.diggusmaximus.config.grouplist"), new ArrayList<>(grouping.groups), new ArrayList<>()).setSaveConsumer(val -> grouping.groups = val));
 

--- a/src/main/java/net/kyrptonaught/diggusmaximus/config/modmenu/ModMenuIntegration.java
+++ b/src/main/java/net/kyrptonaught/diggusmaximus/config/modmenu/ModMenuIntegration.java
@@ -73,8 +73,10 @@ public class ModMenuIntegration implements ModMenuApi {
 
             BlockCategory grouping = DiggusMaximusMod.getGrouping();
             ConfigSection groupSection = new ConfigSection(configScreen, Text.translatable("key.diggusmaximus.config.groupcat"));
+            groupSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.defaulttaggroups"), grouping.defaultTagGroupings, true).setSaveConsumer(val -> grouping.defaultTagGroupings = val));
             groupSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.customgrouping"), grouping.customGrouping, false).setSaveConsumer(val -> grouping.customGrouping = val));
             groupSection.addConfigItem(new GroupingList(Text.translatable("key.diggusmaximus.config.grouplist"), new ArrayList<>(grouping.groups), new ArrayList<>()).setSaveConsumer(val -> grouping.groups = val));
+
 
             ConfigSection shapeSection = new ConfigSection(configScreen, Text.translatable("key.diggusmaximus.config.shapecat"));
             shapeSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.enableshapes"), shapes.enableShapes, false).setSaveConsumer(val -> shapes.enableShapes = val));

--- a/src/main/java/net/kyrptonaught/diggusmaximus/config/modmenu/ModMenuIntegration.java
+++ b/src/main/java/net/kyrptonaught/diggusmaximus/config/modmenu/ModMenuIntegration.java
@@ -55,7 +55,6 @@ public class ModMenuIntegration implements ModMenuApi {
 
             mainSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.minediag"), options.mineDiag, true).setSaveConsumer(val -> options.mineDiag = val));
 
-
             mainSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.autopickup"), options.autoPickup, true).setSaveConsumer(val -> options.autoPickup = val));
             mainSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.requirestool"), options.requiresTool, false).setSaveConsumer(val -> options.requiresTool = val));
             mainSection.addConfigItem(new BooleanItem(Text.translatable("key.diggusmaximus.config.toolduribility"), options.toolDurability, true).setSaveConsumer(val -> options.toolDurability = val));

--- a/src/main/resources/assets/diggusmaximus/lang/en_us.json
+++ b/src/main/resources/assets/diggusmaximus/lang/en_us.json
@@ -24,6 +24,7 @@
   "key.diggusmaximus.config.blacklist": "Blacklisted Blocks",
   "key.diggusmaximus.config.groupcat": "Block Grouping",
   "key.diggusmaximus.config.taggrouping": "Use tag grouping",
+  "key.diggusmaximus.config.defaulttaggroups": "Use default tag groups (e.g. ore tags)",
   "key.diggusmaximus.config.customgrouping": "Use custom grouping",
   "key.diggusmaximus.config.customgroupinggroup": "Block Group",
   "key.diggusmaximus.config.grouplist": "Custom Groups",


### PR DESCRIPTION
## Summary

Adds a list of tags (currently ore tags) that will be grouped by default

## Motivation

During my usage of the mod I noticed stone ores and their deepslate variants weren't grouped together. This was annoying when mining in areas where both exist in the same ore veins so I made this change to use the forked version personally but it might benefit the mod itself.

I see all tags were grouped together previously (comment in `ExcavateHelper.isTheSameBlock`) and while true this is a bit too much, I think it does make sense to group certain tags together.

## Testing

Tested in game to make sure the functionality works and that the config option is respected

## Open Questions

* Translations: Unfortunately I do not know Portuguese nor Chinese so only English translation for the button exists.
* Should other tags be included? Maybe logs / planks?